### PR TITLE
jitterplot: address warnings

### DIFF
--- a/jitterplot
+++ b/jitterplot
@@ -12,6 +12,9 @@ import pandas as pd
 
 __version__ = '0.3'
 
+# disable chained assignment warning
+pd.options.mode.chained_assignment = None
+
 def plot_histogram(filename):
     with open(filename) as file:
         rawdata = json.load(file)
@@ -61,7 +64,7 @@ def plot_all_cpus(df):
         ax.plot("Time", "Value", data=data)
         ax.set_xlabel("Time [s]")
         ax.set_ylabel("Latency [us]")
-        ax.set_ylim(ymin=0, ymax=max_jitter)
+        ax.set_ylim(bottom=0, top=max_jitter)
     plt.show()
 
 


### PR DESCRIPTION
Removed SettingWithCopyWarning as it is not applicable
Updated deprecated ymin/ymax with bottom/top

./jitterplot:60: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

The `ymin` argument was deprecated in Matplotlib 3.0 and
will be removed in 3.2. Use `bottom` instead.
  alternative='`bottom`', obj_type='argument')
The `ymax` argument was deprecated in Matplotlib 3.0 and
will be removed in 3.2. Use `top` instead.
  alternative='`top`', obj_type='argument')

Signed-off-by: Sean V Kelley <seanvk.dev@oregontracks.org>