### PR TITLE
jitterplot: address warnings

### DIFF
--- a/jitterplot
+++ b/jitterplot
@@ -55,13 +55,13 @@ def plot_all_cpus(df):
     axes = fig.subplots(len(ids))
     for ax, data in zip(
         iter(axes),
-        (df[df["CPUID"] == id] for id in ids),
+        (df[df["CPUID"] == id].copy() for id in ids),
     ):
         data["Time"] = data["Seconds"] + data["Nanoseconds"] * 10**-9
         ax.plot("Time", "Value", data=data)
         ax.set_xlabel("Time [s]")
         ax.set_ylabel("Latency [us]")
-        ax.set_ylim(ymin=0, ymax=max_jitter)
+        ax.set_ylim(bottom=0, top=max_jitter)
     plt.show()
 
 


### PR DESCRIPTION
In plot_all_cpus() data is a slice of df and to address
the SettingWithCopyWarning, it needs to be identified as
as a copy().  Updated deprecated ymin/ymax with bottom/top

./jitterplot:60: SettingWithCopyWarning:
A value is trying to be set on a copy of a slice from a DataFrame.
Try using .loc[row_indexer,col_indexer] = value instead

The `ymin` argument was deprecated in Matplotlib 3.0 and
will be removed in 3.2. Use `bottom` instead.
  alternative='`bottom`', obj_type='argument')
The `ymax` argument was deprecated in Matplotlib 3.0 and
will be removed in 3.2. Use `top` instead.
  alternative='`top`', obj_type='argument')

Signed-off-by: Sean V Kelley <seanvk.dev@oregontracks.org>