### PR TITLE
Make HDF5 support conditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ else
 	CFLAGS += -O2
 endif
 
+# Determine if HDF5 support will be built into jittersamples
+JSCC=${CC}
+ifneq ("$(wildcard /usr/include/hdf5.h)", "")
+	CFLAGS += -DCONFIG_HDF5
+	JSCC = h5cc -shlib
+endif
+
 TARGETS=jitterdebugger jittersamples
 
 all: $(TARGETS)
@@ -20,9 +27,9 @@ jitterdebugger: jitterutils.o jitterwork.o jittersysinfo.o jitterdebugger.o
 
 jittersamples: export HDF5_CC=${CC}
 jittersamples: jitterutils.c jittersamples.c
-	h5cc ${CFLAGS} -c jitterutils.c
-	h5cc ${CFLAGS} -c jittersamples.c
-	h5cc -shlib jitterutils.o jittersamples.o -o jittersamples
+	${JSCC} ${CFLAGS} -c jitterutils.c
+	${JSCC} ${CFLAGS} -c jittersamples.c
+	${JSCC} jitterutils.o jittersamples.o -o jittersamples
 
 PHONY: .clean
 clean:

--- a/jittersamples.c
+++ b/jittersamples.c
@@ -15,8 +15,10 @@
 #include <netdb.h>
 #include <unistd.h>
 
+#ifdef CONFIG_HDF5
 #include <hdf5.h>
 #include <H5PTpublic.h>
+#endif
 
 #include "jitterdebugger.h"
 
@@ -43,11 +45,14 @@ static void output_csv(FILE *input, FILE *output)
 #define BLOCK_SIZE 10000
 
 struct cpu_data {
+#ifdef CONFIG_HDF5
 	hid_t set;
+#endif
 	uint64_t count;
 	struct latency_sample *data;
 };
 
+#ifdef CONFIG_HDF5
 static void output_hdf5(FILE *input, const char *ofile, unsigned int cpus_online)
 {
 	struct cpu_data *cpudata;
@@ -155,6 +160,12 @@ static void output_hdf5(FILE *input, const char *ofile, unsigned int cpus_online
 	H5Tclose(type);
 	H5Fclose(file);
 }
+#else
+static void output_hdf5(FILE *input, const char *ofile, unsigned int cpus_online)
+{
+	printf("HDF5 output is not supported by this jittersamples binary.\n");
+}
+#endif /* CONFIG_HDF5 */
 
 static void dump_samples(const char *port)
 {


### PR DESCRIPTION
While everyone knows that having support for a well-structured
output format is the best thing since sliced bread, HDF5 creates
a dependency for a library that is relatively unknown with the
core user group of jitterdebugger. Make HDF5 support conditional
on wether the library is available or not.

Signed-off-by: Wolfgang Mauerer <wolfgang.mauerer@oth-regensburg.de>