### PR TITLE
jitterplot: add a way to plot into a file

### DIFF
--- a/jitterplot
+++ b/jitterplot
@@ -16,7 +16,7 @@ __version__ = '0.3'
 # https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#evaluation-order-matters
 pd.options.mode.chained_assignment = None
 
-def plot_histogram(filename):
+def plot_histogram(filename, outfilename):
     with open(filename) as file:
         rawdata = json.load(file)
 
@@ -40,6 +40,8 @@ def plot_histogram(filename):
 
     L = ax.legend()
     plt.setp(L.texts, family='monospace')
+    if outfilename is not None:
+        plt.savefig(outfilename)
     plt.show()
 
 def load_samples(filename):
@@ -51,7 +53,7 @@ def load_samples(filename):
     df = pd.DataFrame(data)
     return df
 
-def plot_all_cpus(df):
+def plot_all_cpus(df, outfilename):
     ids = df["CPUID"].unique()
     max_jitter = max(df["Value"])
 
@@ -66,6 +68,8 @@ def plot_all_cpus(df):
         ax.set_xlabel("Time [s]")
         ax.set_ylabel("Latency [us]")
         ax.set_ylim(bottom=0, top=max_jitter)
+    if outfilename is not None:
+        plt.savefig(outfilename)
     plt.show()
 
 
@@ -73,6 +77,8 @@ def main():
     ap = argparse.ArgumentParser(description='Plot statistics collected with jitterdebugger')
     ap.add_argument('--version', action='version',
                     version='%(prog)s ' + __version__)
+    ap.add_argument('--output', help='output file name to save figure',
+                    default=None, action='store', type=str)
     sap = ap.add_subparsers(dest='cmd')
 
     hrs = sap.add_parser('hist', help='Print historgram')
@@ -86,14 +92,14 @@ def main():
         fname = args.HIST_FILE
         if os.path.isdir(fname):
             fname = fname + '/results.json'
-        plot_histogram(fname)
+        plot_histogram(fname, args.output)
     elif args.cmd == 'samples':
         fname = args.SAMPLE_FILE
         if os.path.isdir(fname):
             fname = fname + '/samples.raw'
 
         df = load_samples(fname)
-        plot_all_cpus(df)
+        plot_all_cpus(df, args.output)
 
 if __name__ == '__main__':
     main()

--- a/man/jitterplot.1
+++ b/man/jitterplot.1
@@ -20,16 +20,23 @@ Show help text and exit.
 .TP
 .BI "--version"
 Show jitterplot version.
+.TP
+.BI "--output <file>"
+Filename to save the figure to, for non-interactive plotting. The format
+can be controlled via the file extension (e.g. "png", "pdf", "svg")
+
 .SH EXAMPLES
 .EX
 # jitterdebugger -f results.json
 ^C
 # jitterplot hist results.json
+# jitterplot --output /tmp/hist.pdf hist results.json
 
 # jitterdebugger -o samples.raw
 ^C
 # jittersamples samples.raw > samples.txt
 # jitterplot samples samples.txt
+# jitterplot --output /tmp/samples.png samples samples.txt
 .EE
 .SH SEE ALSO
 .ad l


### PR DESCRIPTION
We might be running in a place where interactive operations are not
possible, let alone graphical interaction based on a popup window.

For those cases add a cmdline argument to plot into a file. When such a
filename is given, we save the figure and continue as before. So one can
still interact and save another manually created copy.

Signed-off-by: Henning Schild <henning.schild@siemens.com>