### PR TITLE
add axis labels to the plot

### DIFF
--- a/jitterplot
+++ b/jitterplot
@@ -45,11 +45,10 @@ def plot_cdf(filename, outfilename):
         cpu_id = cpu_id + 1
 
     L = ax.legend()
-    plt.xscale('log')
     plt.grid(color='lightgrey', linestyle='-', linewidth=1, which='both')
     plt.yticks(ticks=np.arange(0, 1.1, 0.1))
     plt.xlabel('jitter [us]')
-    plt.ylabel('CDF')
+    plt.ylabel('probability')
 
     plt.setp(L.texts, family='monospace')
     if outfilename is not None:
@@ -82,6 +81,8 @@ def plot_histogram(filename, outfilename):
 
     L = ax.legend()
     plt.setp(L.texts, family='monospace')
+    plt.xlabel('jitter [us]')
+    plt.ylabel('frequency')
     if outfilename is not None:
         plt.savefig(outfilename)
     plt.show()


### PR DESCRIPTION
currently there is no y axis label of histogram, we could get the label of y axis of "frequency" on the rendered figure liake below: 
<img width="727" alt="image" src="https://github.com/igaw/jitterdebugger/assets/53667804/33541914-5055-48e0-94f0-963e7ed0f16d">

y axis label of cdf also changed to "probability":
<img width="722" alt="image" src="https://github.com/igaw/jitterdebugger/assets/53667804/ccc72a14-d402-4c44-acaf-b626bfd7ddf5">
