### PR TITLE
Building for musl

### DIFF
--- a/jd_plugin.c
+++ b/jd_plugin.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#define _GNU_SOURCE
+
 #include <strings.h>
 
 #include "jitterdebugger.h"

--- a/jd_samples_csv.c
+++ b/jd_samples_csv.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#define _GNU_SOURCE
+
 #include <inttypes.h>
 #include <errno.h>
 

--- a/jd_work.c
+++ b/jd_work.c
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
 
+#define _GNU_SOURCE
+
 #include <sys/wait.h>
 #include <sys/types.h>
 #include <unistd.h>

--- a/jitterdebugger.c
+++ b/jitterdebugger.c
@@ -338,14 +338,21 @@ static void *worker(void *arg)
 {
 	struct stats *s = arg;
 	struct timespec now, next, interval;
-	sigset_t mask;
+	sigset_t signal_mask;
+	cpu_set_t cpu_mask;
 	uint64_t diff;
 	int err;
 
 	/* Don't handle any signals */
-	sigfillset(&mask);
-	if (sigprocmask(SIG_BLOCK, &mask, NULL) < 0)
+	sigfillset(&signal_mask);
+	if (sigprocmask(SIG_BLOCK, &signal_mask, NULL) < 0)
 		err_handler(errno, "sigprocmask()");
+
+	CPU_ZERO(&cpu_mask);
+	CPU_SET(s->affinity, &cpu_mask);
+	err = pthread_setaffinity_np(pthread_self(), sizeof(cpu_mask), &cpu_mask);
+	if (err)
+		err_handler(err, "pthread_setaffinity_np()");
 
 	s->tid = __gettid();
 
@@ -403,23 +410,18 @@ static void start_measuring(struct stats *s, struct record_data *rec)
 {
 	struct sched_param sched;
 	pthread_attr_t attr;
-	cpu_set_t mask;
 	unsigned int i, t;
 	int err;
 
 	pthread_attr_init(&attr);
 
 	for (i = 0, t = 0; i < num_threads; i++) {
-		CPU_ZERO(&mask);
-
 		/*
 		 * Skip unset cores. will not crash as long as
 		 * num_threads <= CPU_COUNT(&affinity)
 		 */
 		while (!CPU_ISSET(t, &affinity))
 			t++;
-
-		CPU_SET(t, &mask);
 
 		/* Don't stay on the same core in next loop */
 		s[i].affinity = t++;
@@ -434,10 +436,6 @@ static void start_measuring(struct stats *s, struct record_data *rec)
 			if (!s[i].rb)
 				err_handler(ENOMEM, "ringbuffer_create()");
 		}
-
-		err = pthread_attr_setaffinity_np(&attr, sizeof(mask), &mask);
-		if (err)
-			err_handler(err, "pthread_attr_setaffinity_np()");
 
 		err = pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
 		if (err)
@@ -459,8 +457,7 @@ static void start_measuring(struct stats *s, struct record_data *rec)
 				fprintf(stderr, "No permission to set the "
 					"scheduling policy and/or priority\n");
 			else if (err == EINVAL)
-				fprintf(stderr, "Invalid settings in thread attributes. "
-					"Check your affinity mask\n");
+				fprintf(stderr, "Invalid settings in thread attributes\n");
 			err_handler(err, "pthread_create()");
 		}
 	}

--- a/jitterdebugger.h
+++ b/jitterdebugger.h
@@ -14,6 +14,15 @@
 // Results in a 1400 bytes payload per UDP packet
 #define SAMPLES_PER_PACKET 50
 
+#ifndef TEMP_FAILURE_RETRY
+# define TEMP_FAILURE_RETRY(expression) \
+	(__extension__ \
+		({ long int __result; \
+			do __result = (long int) (expression); \
+			while (__result == -1L && errno == EINTR); \
+			__result; }))
+#endif
+
 #define READ_ONCE(x)							\
 ({									\
 	union { typeof(x) __v; char __t[1]; } __u = { .__t = { 0 } };	\

--- a/scripts/genbuiltin
+++ b/scripts/genbuiltin
@@ -1,6 +1,7 @@
 #!/bin/sh
 # SPDX-License-Identifier: MIT
 
+echo "#define _GNU_SOURCE"
 echo "#include \"jitterdebugger.h\""
 echo
 


### PR DESCRIPTION
When building on Alpine/musl, I found:

* it's more strict with `_GNU_SOURCE`. I just added defines in all the src files. Alternatively, we could define it via the Makefile; let me know if you'd rather do it like this.
* it doesn't have `TEMP_FAILURE_RETRY`
* it doesn't have `pthread_attr_setaffinity_np`